### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,6 @@
 name: Backend CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SaaiAravindhRaja/TariffSheriff/security/code-scanning/7](https://github.com/SaaiAravindhRaja/TariffSheriff/security/code-scanning/7)

To fix the issue, you should add a `permissions` key to the workflow. Since the only visible operations are code checkout and running Maven builds and tests, this workflow only requires read access to the repository contents. The recommended way is to add `permissions: contents: read` at the root of the workflow, so it applies to all jobs. 

Specifically, insert the following under the workflow `name` and before the `on:` section in `.github/workflows/backend-ci.yml`, so it is globally scoped and affects all jobs in the workflow. No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
