### PR TITLE
Potential fix for code scanning alert no. 8: Implicit narrowing conversion in compound assignment

### DIFF
--- a/apps/backend/src/main/java/com/tariffsheriff/backend/security/monitoring/SecurityMonitoringService.java
+++ b/apps/backend/src/main/java/com/tariffsheriff/backend/security/monitoring/SecurityMonitoringService.java
@@ -129,7 +129,7 @@ public class SecurityMonitoringService {
         if (user.getFailedLoginAttempts() > MAX_FAILED_LOGIN_ATTEMPTS) {
             // Progressive lockout: double the time for each additional failure
             int extraAttempts = user.getFailedLoginAttempts() - MAX_FAILED_LOGIN_ATTEMPTS;
-            lockoutMinutes *= Math.pow(PROGRESSIVE_LOCKOUT_MULTIPLIER, extraAttempts);
+            lockoutMinutes = (int) (lockoutMinutes * Math.pow(PROGRESSIVE_LOCKOUT_MULTIPLIER, extraAttempts));
             lockoutMinutes = Math.min(lockoutMinutes, 24 * 60); // Max 24 hours
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/SaaiAravindhRaja/TariffSheriff/security/code-scanning/8](https://github.com/SaaiAravindhRaja/TariffSheriff/security/code-scanning/8)

To resolve the implicit narrowing conversion, explicitly cast the result of `Math.pow(PROGRESSIVE_LOCKOUT_MULTIPLIER, extraAttempts)` to an integer, and use normal assignment rather than implicit compound assignment to make the conversion clear. The best way is to update the compound assignment on line 132 to use normal assignment, i.e., `lockoutMinutes = (int) (lockoutMinutes * Math.pow(PROGRESSIVE_LOCKOUT_MULTIPLIER, extraAttempts));`. This ensures that the conversion is explicit and maintains readability.  
Only line 132 in `apps/backend/src/main/java/com/tariffsheriff/backend/security/monitoring/SecurityMonitoringService.java` needs to be updated. No imports or other code changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
