### PR TITLE
Align tariff calculator request binding

### DIFF
--- a/apps/backend/src/main/java/com/tariffsheriff/backend/tariff/dto/TariffRateRequestDto.java
+++ b/apps/backend/src/main/java/com/tariffsheriff/backend/tariff/dto/TariffRateRequestDto.java
@@ -1,8 +1,9 @@
 package com.tariffsheriff.backend.tariff.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-
 import lombok.Data;
 
 @Data
@@ -18,6 +19,10 @@ public class TariffRateRequestDto {
     private BigDecimal overheadCost;
     private BigDecimal profit;
     private BigDecimal otherCosts;
-    private BigDecimal FOB;
+
+    @JsonProperty("fob")
+    @JsonAlias("FOB")
+    private BigDecimal fob;
+
     private BigDecimal nonOriginValue;
 }

--- a/apps/backend/src/main/java/com/tariffsheriff/backend/web/error/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tariffsheriff/backend/web/error/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ package com.tariffsheriff.backend.web.error;
 import com.tariffsheriff.backend.service.exception.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,20 +15,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex, HttpServletRequest req) {
         ErrorResponse body = build(HttpStatus.NOT_FOUND, ex.getMessage(), req.getRequestURI());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
     }
 
-    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class, IllegalArgumentException.class})
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class, IllegalArgumentException.class, HttpMessageNotReadableException.class})
     public ResponseEntity<ErrorResponse> handleBadRequest(Exception ex, HttpServletRequest req) {
-        ErrorResponse body = build(HttpStatus.BAD_REQUEST, ex.getMessage(), req.getRequestURI());
+        log.debug("Bad request on {}: {}", req.getRequestURI(), ex.getMessage());
+        ErrorResponse body = build(HttpStatus.BAD_REQUEST, extractMessage(ex), req.getRequestURI());
         return ResponseEntity.badRequest().body(body);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneric(Exception ex, HttpServletRequest req) {
+        log.error("Unexpected error on {}", req.getRequestURI(), ex);
         ErrorResponse body = build(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error", req.getRequestURI());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
     }
@@ -38,6 +45,12 @@ public class GlobalExceptionHandler {
         body.setPath(path);
         return body;
     }
-}
 
+    private static String extractMessage(Exception ex) {
+        if (ex instanceof HttpMessageNotReadableException readable && readable.getMostSpecificCause() != null) {
+            return readable.getMostSpecificCause().getMessage();
+        }
+        return ex.getMessage();
+    }
+}
 

--- a/apps/backend/src/test/java/com/tariffsheriff/backend/TariffCalculationIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tariffsheriff/backend/TariffCalculationIntegrationTest.java
@@ -59,7 +59,7 @@ class TariffCalculationIntegrationTest {
         rq.setOverheadCost(new BigDecimal("50.00"));
         rq.setProfit(new BigDecimal("50.00"));
         rq.setOtherCosts(new BigDecimal("0.00"));
-        rq.setFOB(new BigDecimal("1000.00"));
+        rq.setFob(new BigDecimal("1000.00"));
         rq.setNonOriginValue(new BigDecimal("400.00"));
 
         BigDecimal result = calculationService.calculateTariffRate(rq);
@@ -69,7 +69,7 @@ class TariffCalculationIntegrationTest {
             .add(rq.getOverheadCost())
             .add(rq.getProfit())
             .add(rq.getOtherCosts())
-            .divide(rq.getFOB(), 6, RoundingMode.HALF_UP);
+            .divide(rq.getFob(), 6, RoundingMode.HALF_UP);
 
         TariffRate mfnTop = mfn.get(0);
         TariffRate prefTop = pref.get(0);
@@ -83,7 +83,7 @@ class TariffCalculationIntegrationTest {
         System.out.println("importer_id=" + rq.getImporter_id() + ", origin_id=" + rq.getOrigin_id() + ", hs_product_id=" + rq.getHsCode());
         System.out.println("total_value=" + rq.getTotalValue().toPlainString() + ", quantity=" + rq.getQuantity());
         System.out.println("material=" + rq.getMaterialCost().toPlainString() + ", labour=" + rq.getLabourCost().toPlainString() + ", overhead=" + rq.getOverheadCost().toPlainString() + ", profit=" + rq.getProfit().toPlainString() + ", other=" + rq.getOtherCosts().toPlainString());
-        System.out.println("FOB=" + rq.getFOB().toPlainString() + ", RVC=" + rvc.setScale(6, RoundingMode.HALF_UP).toPlainString());
+        System.out.println("FOB=" + rq.getFob().toPlainString() + ", RVC=" + rvc.setScale(6, RoundingMode.HALF_UP).toPlainString());
         System.out.println("rvc_threshold_percent=" + (rvcThresholdPercent != null ? rvcThresholdPercent.toPlainString() : "<none>") +
             ", rvc_threshold_ratio=" + (rvcThresholdRatio != null ? rvcThresholdRatio.toPlainString() : "<none>"));
 
@@ -100,5 +100,4 @@ class TariffCalculationIntegrationTest {
         assertThat(result).isNotNull();
     }
 }
-
 

--- a/apps/backend/src/test/java/com/tariffsheriff/backend/tariff/controller/TariffRateControllerTest.java
+++ b/apps/backend/src/test/java/com/tariffsheriff/backend/tariff/controller/TariffRateControllerTest.java
@@ -1,0 +1,96 @@
+package com.tariffsheriff.backend.tariff.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tariffsheriff.backend.tariff.dto.TariffRateRequestDto;
+import com.tariffsheriff.backend.tariff.service.TariffCalculationService;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TariffRateController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TariffRateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TariffCalculationService tariffCalculationService;
+
+    @Test
+    void calculateAcceptsLowercaseFob() throws Exception {
+        when(tariffCalculationService.calculateTariffRate(any())).thenReturn(BigDecimal.ZERO);
+
+        mockMvc.perform(post("/api/tariff-rate/calculate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"importer_id\":1," +
+                    "\"origin_id\":2," +
+                    "\"hsCode\":1," +
+                    "\"quantity\":100," +
+                    "\"totalValue\":500000," +
+                    "\"materialCost\":200000," +
+                    "\"labourCost\":80000," +
+                    "\"overheadCost\":50000," +
+                    "\"profit\":30000," +
+                    "\"otherCosts\":20000," +
+                    "\"fob\":400000," +
+                    "\"nonOriginValue\":50000}"))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<TariffRateRequestDto> captor = ArgumentCaptor.forClass(TariffRateRequestDto.class);
+        verify(tariffCalculationService).calculateTariffRate(captor.capture());
+        assertThat(captor.getValue().getFob()).isEqualByComparingTo(new BigDecimal("400000"));
+    }
+
+    @Test
+    void calculateAcceptsUppercaseFobAlias() throws Exception {
+        when(tariffCalculationService.calculateTariffRate(any())).thenReturn(BigDecimal.ZERO);
+
+        mockMvc.perform(post("/api/tariff-rate/calculate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"importer_id\":1," +
+                    "\"origin_id\":2," +
+                    "\"hsCode\":1," +
+                    "\"quantity\":100," +
+                    "\"totalValue\":500000," +
+                    "\"materialCost\":200000," +
+                    "\"labourCost\":80000," +
+                    "\"overheadCost\":50000," +
+                    "\"profit\":30000," +
+                    "\"otherCosts\":20000," +
+                    "\"FOB\":250000," +
+                    "\"nonOriginValue\":50000}"))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<TariffRateRequestDto> captor = ArgumentCaptor.forClass(TariffRateRequestDto.class);
+        verify(tariffCalculationService).calculateTariffRate(captor.capture());
+        assertThat(captor.getValue().getFob()).isEqualByComparingTo(new BigDecimal("250000"));
+    }
+
+    @Test
+    void calculateReturnsBadRequestForUnreadablePayload() throws Exception {
+        mockMvc.perform(post("/api/tariff-rate/calculate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"importer_id\":1," +
+                    "\"fob\":\"not-a-number\"}"))
+            .andExpect(status().isBadRequest());
+
+        verify(tariffCalculationService, never()).calculateTariffRate(any());
+    }
+}


### PR DESCRIPTION
- Fixed 500 server error when calling /api/tariff-rate/calculate
- Make errors surface to server's log